### PR TITLE
Obter URL do SWAPI por variável de ambiente

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 spring.data.mongodb.uri=mongodb+srv://admin:admin@starwarsdb.ewfl0.mongodb.net/starwarsdb?retryWrites=true&w=majority
 
 ### API Star Wars ###
-api.star.wars=https://swapi.dev/api/
+api.star.wars=${URL_SWAPI}
 
 ### Swagger 3 ###
 springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
Será obtida a URL pela forma de variável de ambiente, pois a mesma foi mudada recentemente e não se sabe quando pode ocorrer a troca novamente.

Fechar #15 